### PR TITLE
ci: add GHA workflow for linting and testing

### DIFF
--- a/.github/actions/go-coverage/action.yml
+++ b/.github/actions/go-coverage/action.yml
@@ -1,0 +1,154 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
+name: 'Go Coverage'
+description: 'Creates a coverage message in a PR comment'
+
+inputs:
+  working-directory:
+    description: 'Location of go.mod where tests should run'
+    required: false
+    default: '.'
+  gotest-packages:
+    description: 'The Go module path for the packages and paths to test. Defaults to ./...'
+    required: false
+    default: './...'
+  gotest-arguments:
+    description: 'Additional arguments to pass to "go test", e.g. "-race".'
+    required: false
+    default: ''
+  coverage-threshold-min:
+    description: 'The minimum coverage percentage to regarded as acceptable.'
+    required: false
+    default: '50'
+  coverage-threshold-healthy:
+    description: 'The coverage percentage to regard as healthy for this codebase.'
+    required: false
+    default: '75'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup outputs
+      id: setup
+      working-directory: '${{ inputs.working-directory }}'
+      shell: bash
+      run: |
+          # find PR for branch
+          pr_number="${PR_NUMBER}"
+          if [[ -z "${pr_number:-}" ]]; then
+            echo "determining PR from branch"
+            pr_number="$(gh pr list --state open --head "${branch_name}" --repo "${REPOSITORY:-}" --json number | jq -r '.[0].number | select(. != null)')"
+          fi
+          echo "pr=${pr_number}" >> "$GITHUB_OUTPUT"
+
+          # create a temp directory for the results
+          tmp="$(mktemp --directory 'go-tests.XXXXXXXX')"
+          mkdir -p "$tmp"
+
+          echo "artifacts-dir=${tmp}" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: "${{ github.token }}"
+        PR_NUMBER: "${{ github.event.number }}"
+
+    - name: Install tooling dependencies
+      working-directory: '${{ inputs.working-directory }}'
+      shell: bash
+      run: |
+          # install required tooling
+          go install github.com/boumenot/gocover-cobertura@v1.2.0
+          go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
+
+    - name: Run tests
+      working-directory: '${{ inputs.working-directory }}'
+      shell: bash
+      run: |
+        # run go test
+        go test "${GOTEST_PACKAGES}" -json -v "-coverprofile=${ARTIFACTS_DIR}/coverage.out" -covermode atomic ${GOTEST_ARGUMENTS} 2>&1 | tee "${ARTIFACTS_DIR}/gotest.log" | gotestfmt
+      env:
+        ARTIFACTS_DIR: "${{ steps.setup.outputs.artifacts-dir }}"
+        GOTEST_PACKAGES: "${{ inputs.gotest-packages }}"
+        GOTEST_ARGUMENTS: "${{ inputs.gotest-arguments }}"
+
+    - name: Process package exclusions
+      working-directory: '${{ inputs.working-directory }}'
+      shell: bash
+      run: |
+        # exclude packages from coverage based on optional ".coverage-exclusions" configuration file
+        configuration_file=".coverage-exclusions"
+        coverage_file="${ARTIFACTS_DIR}/coverage.out"
+
+        if [[ -e "${configuration_file}" ]]; then
+          echo "Filtering coverage exclusions"
+
+          while IFS="" read -r exclusion
+          do
+            # ignore empty lines and comments
+            if [[ -z "${exclusion}" || "${exclusion}" = \#* ]]; then
+              continue
+            fi
+
+            printf 'exclude %s\n' "${exclusion}"
+
+            # each line in a coverage file looks like: github.com/cultureamp/ecrscanresults/registry/ecr.go:85.21,86.27 1 4
+            # excluding by package means matching from the start of the line, then any file name, stopping at the colon
+            grep --invert-match '^'"${exclusion}"'/[^/]*:' "${coverage_file}" > "${coverage_file}.tmp"
+            mv "${coverage_file}.tmp" "${coverage_file}"
+          done < "${configuration_file}"
+        fi
+      env:
+        ARTIFACTS_DIR: "${{ steps.setup.outputs.artifacts-dir }}"
+
+    - name: Convert go coverage to cobertura format
+      id: convert-format
+      shell: bash
+      working-directory: '${{ inputs.working-directory }}'
+      run: |
+        # transform go coverage to cobertura format
+        gocover-cobertura < "${ARTIFACTS_DIR}/coverage.out" > "${ARTIFACTS_DIR}/coverage.xml"
+
+        echo "cobertura-coverage=${ARTIFACTS_DIR}/coverage.xml" >> "${GITHUB_OUTPUT}"
+      env:
+        ARTIFACTS_DIR: "${{ steps.setup.outputs.artifacts-dir }}"
+
+    - name: Generate code coverage report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: '${{ inputs.working-directory }}/${{ steps.convert-format.outputs.cobertura-coverage }}'
+        badge: false
+        fail_below_min: false
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: true
+        indicators: true
+        output: both
+        thresholds: '${{ inputs.coverage-threshold-min }} ${{ inputs.coverage-threshold-healthy }}'
+
+    - name: Add Coverage PR Comment
+      if: steps.setup.outputs.pr != ''
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        recreate: true
+        number: "${{ steps.setup.outputs.pr }}"
+        path: code-coverage-results.md
+
+    - name: Write to Job Summary
+      shell: bash
+      run: |
+        # write coverage to job summary
+        cat code-coverage-results.md >> "${GITHUB_STEP_SUMMARY}"
+
+    - name: Cleanup
+      if: 'always()'
+      working-directory: '${{ inputs.working-directory }}'
+      shell: bash
+      run: |
+        # Cleanup whatever temporary files were created by this step, as we
+        # don't need this step cluttering the working directory for other steps.
+        # The code coverage summary step runs in Docker, and doesn't have access
+        # to the runner temp directory.
+        rm -rfv "${ARTIFACTS_DIR}" || true
+        rm -fv code-coverage-results.md || true
+
+      env:
+        ARTIFACTS_DIR: "${{ steps.setup.outputs.artifacts-dir }}"

--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -33,9 +33,9 @@ jobs:
           cache: false # the lint action does its own caching
 
       - name: Lint code
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.57.2
+          version: v1.62.2
           working-directory: src
           args: "-v --timeout=2m"
 

--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -1,0 +1,56 @@
+name: go-checks
+
+on: [push]
+
+defaults:
+  run:
+    working-directory: src
+
+jobs:
+  go-ensure-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - name: Check Go Modules
+        run: make ensure-deps
+
+  go-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+          cache: false # the lint action does its own caching
+
+      - name: Lint code
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.57.2
+          working-directory: src
+          args: "-v --timeout=2m"
+
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - id: Test
+        uses: ./.github/actions/go-coverage
+        with:
+          working-directory: src

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
   - tagliatelle
   - testpackage
   - paralleltest
-  - goerr113
+  - err113
   - dupl
   - forbidigo
   - funlen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
   - prealloc
   - revive
   - depguard
+  - exportloopref
 
 linters-settings:
   gosec:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   - tagliatelle
   - testpackage
   - paralleltest
-  - gomnd
   - goerr113
   - dupl
   - forbidigo
@@ -22,7 +21,6 @@ linters:
   - unparam
   - wsl
   - errname
-  - exhaustivestruct
   - exhaustruct
   - nilnil
   - nlreturn
@@ -37,16 +35,6 @@ linters:
   - prealloc
   - revive
   - depguard
-  # deprecated linters
-  - interfacer
-  - golint
-  - scopelint
-  - maligned
-  - deadcode
-  - ifshort
-  - structcheck
-  - nosnakecase
-  - varcheck
 
 linters-settings:
   gosec:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,34 +8,34 @@ issues:
 linters:
   enable-all: true
   disable:
-  - gochecknoglobals
-  - wrapcheck
-  - varnamelen
-  - tagliatelle
-  - testpackage
-  - paralleltest
-  - err113
-  - dupl
-  - forbidigo
-  - funlen
-  - unparam
-  - wsl
-  - errname
-  - exhaustruct
-  - nilnil
-  - nlreturn
-  - goconst
-  - lll
-  - asciicheck
-  - gocognit
-  - godot
-  - godox
-  - gofumpt
-  - nestif
-  - prealloc
-  - revive
-  - depguard
-  - exportloopref
+    - asciicheck
+    - depguard
+    - dupl
+    - err113
+    - errname
+    - exhaustruct
+    - exportloopref
+    - forbidigo
+    - funlen
+    - gochecknoglobals
+    - gocognit
+    - goconst
+    - godot
+    - godox
+    - gofumpt
+    - lll
+    - nestif
+    - nilnil
+    - nlreturn
+    - paralleltest
+    - prealloc
+    - revive
+    - tagliatelle
+    - testpackage
+    - unparam
+    - varnamelen
+    - wrapcheck
+    - wsl
 
 linters-settings:
   gosec:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,16 +63,6 @@ linters-settings:
     max-complexity: 20
   depguard:
     rules:
-      main:
+      default:
         list-mode: lax # all packages are allowed, unless explicitly denied
-        files: # all Go files, except test files
-          - $all
-          - "!$test"
-        allow:
-          - $gostd # packages from Go standard library
-      test:
-        list-mode: lax
-        files: # test files only
-          - $test
-        allow:
-          - $gostd
+        deny: []

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
   - nestif
   - prealloc
   - revive
+  - depguard
   # deprecated linters
   - interfacer
   - golint
@@ -61,8 +62,3 @@ linters-settings:
         mode: strict
   cyclop:
     max-complexity: 20
-  depguard:
-    rules:
-      default:
-        list-mode: lax # all packages are allowed, unless explicitly denied
-        deny: []

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,3 +61,18 @@ linters-settings:
         mode: strict
   cyclop:
     max-complexity: 20
+  depguard:
+    rules:
+      main:
+        list-mode: lax # all packages are allowed, unless explicitly denied
+        files: # all Go files, except test files
+          - $all
+          - "!$test"
+        allow:
+          - $gostd # packages from Go standard library
+      test:
+        list-mode: lax
+        files: # test files only
+          - $test
+        allow:
+          - $gostd

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cultureamp/examplego/plugin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFailOnMissingEnvironment(t *testing.T) {
@@ -17,7 +18,7 @@ func TestFailOnMissingEnvironment(t *testing.T) {
 
 	err := fetcher.Fetch(&config)
 
-	assert.NotNil(t, err, "fetch should error")
+	assert.Error(t, err, "fetch should error")
 }
 
 func TestFetchConfigFromEnvironment(t *testing.T) {
@@ -28,6 +29,6 @@ func TestFetchConfigFromEnvironment(t *testing.T) {
 
 	err := fetcher.Fetch(&config)
 
-	assert.Nil(t, err, "fetch should not error")
-	assert.Equal(t, config.Message, "test-message", "fetched message should match environment")
+	require.NoError(t, err, "fetch should not error")
+	assert.Equal(t, "test-message", config.Message, "fetched message should match environment")
 }

--- a/src/plugin/example_test.go
+++ b/src/plugin/example_test.go
@@ -20,5 +20,5 @@ func TestDoesAnnotate(t *testing.T) {
 
 	err := examplePlugin.Run(ctx, fetcher, agent)
 
-	assert.Nil(t, err, "should not error")
+	assert.NoError(t, err, "should not error")
 }


### PR DESCRIPTION
Added GHA workflow for linting and testing.

This was copied from `cultureamp/ecr-scan-results-buildkite-plugin` and modified.

Modifications:

- upgraded golangci-lint version
- changed assertions to satisfy `testifylint` linter
- disabled `depguard` and `exportloopref` linters
- removed deprecated linters from config
- renamed `goerr113` to `err113`

