### PR TITLE
feat: add Athens Go proxy configuration for docker

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+    - name: Configure Go environment with access to private modules
+      uses: cultureamp/go-private-modules@v1
+      with:
+        github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: src/go.mod
@@ -26,6 +31,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Configure Go environment with access to private modules
+        uses: cultureamp/go-private-modules@v1
+        with:
+          github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
 
       - uses: actions/setup-go@v5
         with:
@@ -44,6 +54,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Configure Go environment with access to private modules
+        uses: cultureamp/go-private-modules@v1
+        with:
+          github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
 
       - uses: actions/setup-go@v5
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,11 @@ services:
     image: buildkite/plugin-tester:v4.0.0
     volumes:
       - ".:/plugin"
+  build:
+    build:
+      context: src
+      dockerfile: Dockerfile
+      args:
+        - GONOPROXY
+        - GOPRIVATE
+        - GOPROXY

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,16 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 
 FROM ${BUILDER_IMAGE} as builder
 
+ARG NETSKOPE_CERT
+RUN if [ "${NETSKOPE_CERT}z" != "z" ];  then \
+      echo "Installing Netskope MitM certificates" && \
+      mkdir -p /usr/local/share/ca-certificates || true && \
+      echo "${NETSKOPE_CERT}" >> /etc/ssl/certs/ca-certificates.crt && \
+      echo "${NETSKOPE_CERT}" >> /usr/local/share/ca-certificates/netskope.crt && \
+      apk --no-cache add ca-certificates && \
+      update-ca-certificates; \
+    fi
+
 # Ensure ca-certficates are up to date
 RUN update-ca-certificates
 
@@ -14,6 +24,10 @@ RUN go mod download
 RUN go mod verify
 
 COPY . ./
+
+ARG GONOPROXY
+ARG GOPRIVATE
+ARG GOPROXY
 
 # build as a static binary without debug symbols
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \


### PR DESCRIPTION
# Purpose
This PR adds a Docker Compose command to build our Go binaries and put them in an image, and expands on the existing Dockerfile to provide pass-through of environment variables for our Go Proxy.

# Context
We need these values in order to use our private module proxy.