### PR TITLE
fix: executable name does not match release artifacts

### DIFF
--- a/.github/workflows/plugin-lint.yaml
+++ b/.github/workflows/plugin-lint.yaml
@@ -1,0 +1,21 @@
+name: Plugin Lint
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Lint
+        run: docker compose run --rm lint
+# TODO: Setup testing once we begin the flesh out the plugin
+# - name: Test
+#   run: docker compose run --rm tests

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Welcome to your "ecs-task-runner-rnd" project!
+# ECS Task Runner
+
+## Example
+
+Add the following lines to your `pipeline.yml`:
+
+```yml
+steps:
+  - plugins:
+      - cultureamp/ecs-task-runner#v0.0.0:
+          message: "This is the message that will be annotated!"
+```
+
+## Configuration
+
+### `message` (Required, string)
+
+The message to annotate onto the build.

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -72,7 +72,7 @@ get_version() {
 download_binary_and_run() {
   get_architecture || return 1
   local _arch="$RETVAL"
-  local _executable="ecs-task-runner"
+  local _executable="ecs-task-runner-buildkite-plugin"
   local _repo="https://github.com/cultureamp/ecs-task-runner-buildkite-plugin"
 
   get_version || return 1

--- a/src/.goreleaser.yaml
+++ b/src/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - binary: ecs-task-runner
     env:
@@ -20,7 +21,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   use: github-native


### PR DESCRIPTION
# Purpose 🎯

These changes correct a typo for the release artifact name in the command hook for the plugin. Internally, we keep the `buildkite-plugin` suffix, but this was removed in the script. As a result, pipelines that may try to use this plugin will fail because `curl` is unable to find the appropriate release artifact (refer to notes).

# Context 🧠 

- Identified during end-to-end tests following the incorporation of the end-to-end template.

# Notes 📓 

Below is an example of the failed run referencing the incorrect release artifact path.

```plaintext
$ /var/lib/buildkite-agent/plugins/github-com-cultureamp-ecs-task-runner-buildkite-plugin/hooks/command
--
  | curl: (22) The requested URL returned error: 404
  | failed to download https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/releases/latest/download/ecs-task-runner_linux_amd64
  | 🚨 Error: The command exited with status 1
```
