### PR TITLE
chore: tweaks following end-to-end verification

### DIFF
--- a/.github/workflows/plugin-lint.yaml
+++ b/.github/workflows/plugin-lint.yaml
@@ -1,4 +1,4 @@
-name: Plugin Lint
+name: Plugin Linting & Testing
 
 on:
   pull_request:
@@ -16,6 +16,6 @@ jobs:
 
       - name: Lint
         run: docker compose run --rm lint
-# TODO: Setup testing once we begin the flesh out the plugin
-# - name: Test
-#   run: docker compose run --rm tests
+
+      - name: Test
+        run: docker compose run --rm tests

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # VIM swap files
 *.swp
 src/*.html
+
+# Go Release artifacts
+src/dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     image: buildkite/plugin-tester:v4.0.0
     volumes:
       - ".:/plugin"
+
   build:
     build:
       context: src

--- a/src/plugin/config.go
+++ b/src/plugin/config.go
@@ -11,7 +11,7 @@ type Config struct {
 type EnvironmentConfigFetcher struct {
 }
 
-const pluginEnvironmentPrefix = "BUILDKITE_PLUGIN_EXAMPLE_GO"
+const pluginEnvironmentPrefix = "BUILDKITE_PLUGIN_ECS_TASK_RUNNER"
 
 func (f EnvironmentConfigFetcher) Fetch(config *Config) error {
 	return envconfig.Process(pluginEnvironmentPrefix, config)

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+load '../lib/download.bash'
+
+#
+# Tests for top-level docker bootstrap command. The rest of the plugin runs in Go.
+#
+
+# Uncomment the following line to debug stub failures
+# export [stub_command]_STUB_DEBUG=/dev/tty
+#export DOCKER_STUB_DEBUG=/dev/tty
+
+#TODO: Update this to reflect what we need to test in the task runner code
+setup() {
+  export BUILDKITE_PLUGIN_ECR_TASK_RUNNER_BUILDKITE_PLUGIN_MESSAGE=true
+}
+
+#TODO: Update this to reflect what we need to test in the task runner code
+teardown() {
+    unset BUILDKITE_PLUGIN_ECR_TASK_RUNNER_BUILDKITE_PLUGIN_MESSAGE
+    rm ./ecs-task-runner-buildkite-plugin || true
+}
+
+create_script() {
+cat > "$1" << EOM
+set -euo pipefail
+
+echo "executing $1:\$@"
+
+EOM
+}
+
+@test "Downloads and runs the command for the current architecture" {
+
+  function downloader() {
+    echo "$@";
+    create_script $2
+  }
+  export -f downloader
+
+  run download_binary_and_run
+
+  unset downloader
+
+  assert_success
+  assert_line --regexp "https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/releases/latest/download/ecs-task-runner-buildkite-plugin_linux_amd64 ecs-task-runner-buildkite-plugin"
+  assert_line --regexp "executing ecs-task-runner-buildkite-plugin"
+}


### PR DESCRIPTION
# Purpose 🎯 

These changes apply tweaks, discoveries, and fixes following the end-to-end tests using the template example in `main, specically the repo at the time of [this commit](https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/tree/b1ac70b1ae3871ada34c85096c497a1fd3067830).

The most notable change is fixing up the Buildkite environment variable prefix for the plugin. Without that change, the plugin will fail to retrieve the parameters from a configured step. 

This confirms that the base we are building on top of works, and any reason why the plugin would fail thereafter would be coming from the changes we have made to add the actual business logic we're adding in https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/pull/1

# Context 🧠 

- [CSRE-4965](https://cultureamp.atlassian.net/browse/CSRE-4965)
- Changes ported from: https://github.com/cultureamp/example-go-buildkite-plugin/pull/2

# Notes 📓 

- [Tested out](https://buildkite.com/culture-amp/permissions-service/builds/2463#019385ac-d39d-44d1-952c-c27dd3c3bc8e/187) in `permissions-service` (pictured)
![image](https://github.com/user-attachments/assets/5d55e6d1-2196-4736-b1c6-d4282d09639a)

![image](https://github.com/user-attachments/assets/98a124e6-1d6b-4e03-92f6-44b9ec76e897)


[CSRE-4965]: https://cultureamp.atlassian.net/browse/CSRE-4965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ