### PR TITLE
revert: add Athens Go proxy configuration for docker 

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -13,11 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure Go environment with access to private modules
-        uses: cultureamp/go-private-modules@v1
-        with:
-          github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
-
       - uses: actions/setup-go@v5
         with:
           go-version-file: src/go.mod
@@ -31,11 +26,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure Go environment with access to private modules
-        uses: cultureamp/go-private-modules@v1
-        with:
-          github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
 
       - uses: actions/setup-go@v5
         with:
@@ -54,11 +44,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Configure Go environment with access to private modules
-        uses: cultureamp/go-private-modules@v1
-        with:
-          github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-    - name: Configure Go environment with access to private modules
-      uses: cultureamp/go-private-modules@v1
-      with:
-        github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
+      - name: Configure Go environment with access to private modules
+        uses: cultureamp/go-private-modules@v1
+        with:
+          github-token: "${{ secrets.GO_PRIVATE_MODULES_TOKEN }}"
 
       - uses: actions/setup-go@v5
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,3 @@ services:
     build:
       context: src
       dockerfile: Dockerfile
-      args:
-        - GONOPROXY
-        - GOPRIVATE
-        - GOPROXY

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -25,10 +25,6 @@ RUN go mod verify
 
 COPY . ./
 
-ARG GONOPROXY
-ARG GOPRIVATE
-ARG GOPROXY
-
 # build as a static binary without debug symbols
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
       -ldflags='-w -s -extldflags "-static"' -a \

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -25,7 +25,7 @@ func TestFetchConfigFromEnvironment(t *testing.T) {
 	var config plugin.Config
 	fetcher := plugin.EnvironmentConfigFetcher{}
 
-	t.Setenv("BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE", "test-message")
+	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_MESSAGE", "test-message")
 
 	err := fetcher.Fetch(&config)
 

--- a/src/plugin/example_test.go
+++ b/src/plugin/example_test.go
@@ -15,7 +15,7 @@ func TestDoesAnnotate(t *testing.T) {
 	ctx := context.Background()
 	annotation := "test-message"
 
-	t.Setenv("BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE", annotation)
+	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_MESSAGE", annotation)
 	agent.Mock.On("Annotate", ctx, annotation, "info", "message").Return(nil)
 
 	err := examplePlugin.Run(ctx, fetcher, agent)


### PR DESCRIPTION
> [!NOTE]
> This change needs to be merged before #1  

# Purpose 🎯

Due to this repo being public-facing, it isn't allowed to access the
private composite action in `cultureamp/go-private-modules`. This
results in an error where the go-checks action fails to run because
it is unable to pull the action.

Since this repository is public and not using private deps, we can
undo this change. 

# Context 🧠 

- Follow up to #4 

# Notes 📓 

- it is worth noting that in the commit: 5125ee96a4453d8497a1ca9ee010bbd0b986dd5f [there was a quirk](https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/pull/4/files#r1867055465) in that due to the bad indentation, the workflow failed to run. However, this didn't seem to surface an error at all. This is why a commit has been added to fix the tests, they never ran during the review of #7, so these issues never surfaced.