### PR TITLE
refactor: change module name format

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module ecs-task-runner
+module github.com/cultureamp/ecs-task-runner-buildkite-plugin
 
 go 1.22.3
 

--- a/src/main.go
+++ b/src/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"os"
 
-	"ecs-task-runner/buildkite"
-	"ecs-task-runner/plugin"
+	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/buildkite"
+	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/plugin"
 )
 
 func main() {

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"ecs-task-runner/plugin"
+	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/plugin"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/src/plugin/task-runner.go
+++ b/src/plugin/task-runner.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	awsinternal "ecs-task-runner/aws"
-	"ecs-task-runner/buildkite"
+	awsinternal "github.com/cultureamp/ecs-task-runner-buildkite-plugin/aws"
+	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/buildkite"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"


### PR DESCRIPTION
The module has been renamed using the format `github.com/<org>/<repo>`. Module imports have been updated appropriately.