### PR TITLE
fix: issues with ecs-task-runner during prototyping

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -5,7 +5,7 @@ author: https://github.com/cultureamp
 requirements: []
 configuration:
   properties:
-    parameterName:
+    parameter-name:
       type: string
     script:
       type: string

--- a/src/aws/ecs.go
+++ b/src/aws/ecs.go
@@ -30,7 +30,7 @@ func SubmitTask(ctx context.Context, ecsAPI EcsClientAPI, input *TaskRunnerConfi
 		Overrides: &types.TaskOverride{
 			ContainerOverrides: []types.ContainerOverride{
 				{
-					Name:    aws.String("migrations-runner"),
+					Name:    aws.String("task-runner"),
 					Command: input.Command,
 				},
 			},
@@ -109,7 +109,7 @@ func FindLogStreamFromTask(ctx context.Context, ecsClientAPI EcsClientAPI, task 
 
 	// We need the logGroupName, streamPrefix, and a container name to be able to produce a FindLogStreamOutput in full
 	if logGroupName == "" || streamPrefix == "" {
-		return LogDetails{}, fmt.Errorf("cannot trace migration output: container logging is not configured on task definition: %v", response.TaskDefinition.TaskDefinitionArn)
+		return LogDetails{}, fmt.Errorf("cannot trace task output: container logging is not configured on task definition: %v", response.TaskDefinition.TaskDefinitionArn)
 	}
 
 	return LogDetails{

--- a/src/plugin/task-runner.go
+++ b/src/plugin/task-runner.go
@@ -8,7 +8,6 @@ import (
 	awsinternal "github.com/cultureamp/ecs-task-runner-buildkite-plugin/aws"
 	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/buildkite"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -89,12 +88,12 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 		}
 	}
 
-	// TODO: Assuming the task only has 1 container. What if there others? Like Datadog sideca
-	if task.Containers[0].ExitCode != aws.Int32(0) {
-		buildkite.LogFailuref("Task stopped with a non-zero exit code:: %d", task.Containers[0].ExitCode)
+	// TODO: Assuming the task only has 1 container. What if there others? Like Datadog sidecar
+	if *task.Containers[0].ExitCode != 0 {
+		buildkite.LogFailuref("Task stopped with a non-zero exit code:: %d\n", *task.Containers[0].ExitCode)
 		// TODO: At about here, a structured return type of "success: true/false" and "error" is returned
 	} else {
-		buildkite.Log("Task completed successfully :)")
+		buildkite.Log("Task completed successfully :) \n")
 		// TODO: At about here, a structured return type of "success: true/false" and "error" is returned
 	}
 

--- a/src/plugin/task-runner.go
+++ b/src/plugin/task-runner.go
@@ -37,7 +37,7 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 	}
 
 	ssmClient := ssm.NewFromConfig(cfg)
-	buildkite.Logf("Retrieving task configuration from: %s", config.ParameterName)
+	buildkite.Logf("Retrieving task configuration from: %s \n", config.ParameterName)
 	configuration, err := awsinternal.RetrieveConfiguration(ctx, ssmClient, config.ParameterName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve configuration: %w", err)

--- a/src/plugin/task-runner.go
+++ b/src/plugin/task-runner.go
@@ -78,7 +78,7 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 	}
 
 	if len(logs) > 0 {
-		buildkite.Logf("CloudWatch Logs for job:")
+		buildkite.Logf("CloudWatch Logs for job: \n")
 		for _, l := range logs {
 			if l.Timestamp != nil {
 				// Applying ISO 8601 format, l.Timestamp is in milliseconds, not very useful in logging
@@ -97,6 +97,6 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 		// TODO: At about here, a structured return type of "success: true/false" and "error" is returned
 	}
 
-	buildkite.Log("done.")
+	buildkite.Log("done. \n")
 	return nil
 }


### PR DESCRIPTION
# Purpose 🎯

These changes feature various fixes that were identified during prototyping of the Buildkite plugin for the `permissions-service`. These fixes will ensure that the plugin will be suitable for future projects to use.

Overall the changes are as follows:

1. kebab-casing is required for Buildkite plug-in properties. otherwise the expected environment variables that the plug-in produces will not be named as what is expected. the kebab-case translates into upper snake case eventually.
2. Newlines have been added to ensure that logs are spaced out correctly and not presented as contiguous strings.
3. A missing pointer dereference has been added that allows proper comparison of the exit code returned by tasks.

# Context 🧠 

- Originating task [CSRE-4494](https://cultureamp.atlassian.net/browse/CSRE-4994)

[CSRE-4494]: https://cultureamp.atlassian.net/browse/CSRE-4494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ