### PR TITLE
fix: expected container name is consistent with construct's container name

### DIFF
--- a/src/aws/ecs.go
+++ b/src/aws/ecs.go
@@ -30,7 +30,7 @@ func SubmitTask(ctx context.Context, ecsAPI EcsClientAPI, input *TaskRunnerConfi
 		Overrides: &types.TaskOverride{
 			ContainerOverrides: []types.ContainerOverride{
 				{
-					Name:    aws.String("task-runner"),
+					Name:    aws.String("migrations-runner"),
 					Command: input.Command,
 				},
 			},


### PR DESCRIPTION
## Purpose
- Uses the new naming convention when attempting to run migration tasks
- Switching to the new naming keeps everything consistent

## Context
- Related to https://github.com/cultureamp/cdk-constructs/pull/1583