### PR TITLE
feat: add configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,23 @@ Add the following lines to your `pipeline.yml`:
 steps:
   - plugins:
       - cultureamp/ecs-task-runner#v0.0.0:
-          message: "This is the message that will be annotated!"
+          parameter-name: "test-parameter"
+          script: "/bin/migrate"
+          timeout: 900
 ```
 
 ## Configuration
 
-### `message` (Required, string)
+### `parameter-name` (Required, string)
+The name or ARN of the parameter in Parameter Store that contains the task definition.
 
-The message to annotate onto the build.
+### `script` (Required, string)
+The name of the script to run in the task. 
+
+### `timeout` (Optional, integer)
+The timeout in seconds that the plugin will wait for the task to complete. If the task does not complete within this time, the plugin will fail. The task execution will continue to run in the background.
+
+Default: 2700
 
 ## Usage
 This plugin is based on an existing pattern in `murmur` where database migrations are run as a task on ECS. To provide additional context for how this plugin is expected to be used, this is the expected pattern:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ steps:
 ### `parameter-name` (Required, string)
 The name or ARN of the parameter in Parameter Store that contains the task definition.
 
-### `command` (Required, string)
-The name of the command to run in the task. 
+### `command` (Optional, string)
+The name of the command to run in the task. When omitted, the task will run the command specified in the parameter.
 
 ### `timeout` (Optional, integer)
 The timeout in seconds that the plugin will wait for the task to complete. If the task does not complete within this time, the plugin will fail. The task execution will continue to run in the background.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ steps:
   - plugins:
       - cultureamp/ecs-task-runner#v0.0.0:
           parameter-name: "test-parameter"
-          script: "/bin/migrate"
+          command: "/bin/migrate"
           timeout: 900
 ```
 
@@ -18,8 +18,8 @@ steps:
 ### `parameter-name` (Required, string)
 The name or ARN of the parameter in Parameter Store that contains the task definition.
 
-### `script` (Required, string)
-The name of the script to run in the task. 
+### `command` (Required, string)
+The name of the command to run in the task. 
 
 ### `timeout` (Optional, integer)
 The timeout in seconds that the plugin will wait for the task to complete. If the task does not complete within this time, the plugin will fail. The task execution will continue to run in the background.
@@ -43,7 +43,7 @@ This plugin comes with some assumed infrastructure that needs to be deployed bef
 - An IAM role for the BK agent to start the task
 - A Parameter Store parameter extending the task definition by providing entrypoint overrides and networking configuration
 - A log group for the task
-- A security group for your service (this can be the [base-infrastructure-for-services](https://github.com/cultureamp/base-infrastructure-for-services) source security group
+- A security group for your service (this can be the [base-infrastructure-for-services](https://github.com/cultureamp/base-infrastructure-for-services) source security group)
 
 This can be visualised below:
 ![The overall flow of this plugin and AWS resources](docs/images/diagram.svg)

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,3 +9,5 @@ configuration:
       type: string
     script:
       type: string
+    timeout:
+      type: integer

--- a/src/aws/ecs.go
+++ b/src/aws/ecs.go
@@ -59,11 +59,10 @@ func SubmitTask(ctx context.Context, ecsAPI EcsClientAPI, input *TaskRunnerConfi
 	return *response.Tasks[0].TaskArn, nil
 }
 
-func WaitForCompletion(ctx context.Context, waiter ecsWaiterAPI, taskArn string) (*ecs.DescribeTasksOutput, error) {
+func WaitForCompletion(ctx context.Context, waiter ecsWaiterAPI, taskArn string, timeOut int) (*ecs.DescribeTasksOutput, error) {
 	cluster := ClusterFromTaskArn(taskArn)
 
-	// TODO: This magic number will be resolved in a future piece of work, not going to refactor this right now
-	maxWaitDuration := 15 * time.Minute //nolint:mnd
+	maxWaitDuration := time.Duration(timeOut) * time.Second
 	result, err := waiter.WaitForOutput(ctx, &ecs.DescribeTasksInput{
 		Cluster: aws.String(cluster),
 		Tasks:   []string{taskArn},

--- a/src/aws/ecs.go
+++ b/src/aws/ecs.go
@@ -19,7 +19,7 @@ type EcsClientAPI interface {
 	DescribeTaskDefinition(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error)
 }
 
-type ecsWaiterAPI interface {
+type EcsWaiterAPI interface {
 	WaitForOutput(ctx context.Context, params *ecs.DescribeTasksInput, maxWaitDur time.Duration, optFns ...func(*ecs.TasksStoppedWaiterOptions)) (*ecs.DescribeTasksOutput, error)
 }
 
@@ -59,7 +59,7 @@ func SubmitTask(ctx context.Context, ecsAPI EcsClientAPI, input *TaskRunnerConfi
 	return *response.Tasks[0].TaskArn, nil
 }
 
-func WaitForCompletion(ctx context.Context, waiter ecsWaiterAPI, taskArn string, timeOut int) (*ecs.DescribeTasksOutput, error) {
+func WaitForCompletion(ctx context.Context, waiter EcsWaiterAPI, taskArn string, timeOut int) (*ecs.DescribeTasksOutput, error) {
 	cluster := ClusterFromTaskArn(taskArn)
 
 	maxWaitDuration := time.Duration(timeOut) * time.Second

--- a/src/aws/ecs_test.go
+++ b/src/aws/ecs_test.go
@@ -403,7 +403,7 @@ func TestWaitForCompletion(t *testing.T) {
 		},
 		"slowpoke": {
 			mockWaitForOutput: func(context.Context, *ecs.DescribeTasksInput, time.Duration, ...func(*ecs.TasksStoppedWaiterOptions)) (*ecs.DescribeTasksOutput, error) {
-				return nil, errors.New("task timed out: computer is full of beanz")
+				return nil, errors.New("task timed out: computer still thinking")
 			},
 		},
 	}
@@ -438,7 +438,7 @@ func TestWaitForCompletion(t *testing.T) {
 			name:     "given a task that times out, it should return an error",
 			input:    "arn:aws:ecs:us-west-2:123456789012:task/test-cluster/07cc583696bd44e0be450bff7314ddaf",
 			waiter:   mockedWaiter["slowpoke"],
-			expected: expectedReturn{nil, errors.New("task timed out: computer is full of beanz")},
+			expected: expectedReturn{nil, errors.New("task timed out: computer still thinking")},
 		},
 	}
 

--- a/src/aws/ecs_test.go
+++ b/src/aws/ecs_test.go
@@ -365,7 +365,7 @@ func TestWaitForCompletion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := WaitForCompletion(context.TODO(), tc.waiter, tc.input)
+			result, err := WaitForCompletion(context.TODO(), tc.waiter, tc.input, 15)
 			t.Logf("result: '%v'", err)
 			t.Logf("expected: detail: %v, reason: %v", *tc.expected.Failures[0].Detail, *tc.expected.Failures[0].Reason)
 

--- a/src/buildkite/agent.go
+++ b/src/buildkite/agent.go
@@ -11,10 +11,14 @@ import (
 	osexec "golang.org/x/sys/execabs"
 )
 
+type AgentAPI interface {
+	Annotate(ctx context.Context, message string, style string, annotationContext string) error
+}
+
 type Agent struct {
 }
 
-func (a *Agent) Annotate(ctx context.Context, message string, style string, annotationContext string) error {
+func (a Agent) Annotate(ctx context.Context, message string, style string, annotationContext string) error {
 	return execCmd(ctx, "buildkite-agent", &message, "annotate", "--style", style, "--context", annotationContext)
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	awsinternal "github.com/cultureamp/ecs-task-runner-buildkite-plugin/aws"
 	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/buildkite"
 	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/plugin"
 )
@@ -13,7 +14,7 @@ func main() {
 	fetcher := plugin.EnvironmentConfigFetcher{}
 	taskRunnerPlugin := plugin.TaskRunnerPlugin{}
 
-	err := taskRunnerPlugin.Run(ctx, fetcher)
+	err := taskRunnerPlugin.Run(ctx, fetcher, awsinternal.WaitForCompletion)
 
 	if err != nil {
 		buildkite.LogFailuref("plugin execution failed: %s\n", err.Error())

--- a/src/plugin/config.go
+++ b/src/plugin/config.go
@@ -7,6 +7,7 @@ import (
 type Config struct {
 	ParameterName string `required:"true" split_words:"true"`
 	Script        string `required:"true" split_words:"true"`
+	TimeOut       int    `default:"2700"  split_words:"true"`
 }
 
 type EnvironmentConfigFetcher struct {

--- a/src/plugin/config.go
+++ b/src/plugin/config.go
@@ -7,7 +7,7 @@ import (
 type Config struct {
 	ParameterName string `required:"true"  split_words:"true"`
 	Command       string `required:"false" split_words:"true"`
-	TimeOut       int    `default:"2700"  split_words:"true"`
+	TimeOut       int    `default:"2700"   split_words:"true"`
 }
 
 type EnvironmentConfigFetcher struct {

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -24,7 +24,7 @@ func TestFailOnMissingRequiredEnvironment(t *testing.T) {
 			name: "all required parameters are unset",
 			disabledEnvVars: []string{
 				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME",
-        "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_COMMAND",
+				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_COMMAND",
 				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIMEOUT",
 			},
 			enabledEnvVars: map[string]string{},

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -25,6 +25,7 @@ func TestFailOnMissingRequiredEnvironment(t *testing.T) {
 			disabledEnvVars: []string{
 				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME",
 				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_SCRIPT",
+				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIMEOUT",
 			},
 			enabledEnvVars: map[string]string{},
 			expectedErr:    "required key BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME missing value",
@@ -72,18 +73,27 @@ func TestFailOnMissingRequiredEnvironment(t *testing.T) {
 func TestFetchConfigFromEnvironment(t *testing.T) {
 	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME")
 	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_SCRIPT")
+	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT")
 
 	var config plugin.Config
 	fetcher := plugin.EnvironmentConfigFetcher{}
 
 	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME", "test-parameter")
 	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_SCRIPT", "hello-world")
+	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT", "600")
 
 	err := fetcher.Fetch(&config)
 
 	require.NoError(t, err, "fetch should not error")
 	assert.Equal(t, "test-parameter", config.ParameterName, "fetched message should match environment")
 	assert.Equal(t, "hello-world", config.Script, "fetched message should match environment")
+	assert.Equal(t, 600, config.TimeOut, "fetched message should match environment")
+
+	// test default value
+	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT")
+	err = fetcher.Fetch(&config)
+	require.NoError(t, err, "fetch should not error")
+	assert.Equal(t, 2700, config.TimeOut, "fetched message should match environment")
 }
 
 func unsetEnv(t *testing.T, key string) {

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -86,14 +86,14 @@ func TestFetchConfigFromEnvironment(t *testing.T) {
 
 	require.NoError(t, err, "fetch should not error")
 	assert.Equal(t, "test-parameter", config.ParameterName, "fetched message should match environment")
-	assert.Equal(t, "hello-world", config.Script, "fetched message should match environment")
-	assert.Equal(t, 600, config.TimeOut, "fetched message should match environment")
+	assert.Equal(t, "hello-world", config.Script, "fetched script should match environment")
+	assert.Equal(t, 600, config.TimeOut, "fetched timeout should match environment")
 
 	// test default value
 	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT")
 	err = fetcher.Fetch(&config)
 	require.NoError(t, err, "fetch should not error")
-	assert.Equal(t, 2700, config.TimeOut, "fetched message should match environment")
+	assert.Equal(t, 2700, config.TimeOut, "fetched timeout should match environment")
 }
 
 func unsetEnv(t *testing.T, key string) {

--- a/src/plugin/task-runner.go
+++ b/src/plugin/task-runner.go
@@ -27,6 +27,7 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 	if err != nil {
 		return fmt.Errorf("plugin configuration error: %w", err)
 	}
+	buildKiteAgent := buildkite.Agent{}
 
 	buildkite.Log("Executing task-runner plugin\n")
 
@@ -59,6 +60,7 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 	})
 	result, err := awsinternal.WaitForCompletion(ctx, waiterClient, taskArn, config.TimeOut)
 	if err != nil {
+		_ = buildKiteAgent.Annotate(ctx, fmt.Sprintf("Task did not complete successfully within timeout %v", result.Failures[0]), "error", "ecs-task-runner")
 		return fmt.Errorf("failed to wait for task completion: %w\nFailure information: %v", err, result.Failures[0])
 	}
 	// In a successful scenario for task completion, we would have a `tasks` slice with a single element

--- a/src/plugin/task-runner.go
+++ b/src/plugin/task-runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	awsinternal "github.com/cultureamp/ecs-task-runner-buildkite-plugin/aws"
@@ -18,13 +19,14 @@ import (
 type TaskRunnerPlugin struct {
 }
 
+type WaitForCompletion func(ctx context.Context, waiter awsinternal.EcsWaiterAPI, taskArn string, timeOut int) (*ecs.DescribeTasksOutput, error)
 type ConfigFetcher interface {
 	Fetch(config *Config) error
 }
 
-func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) error {
+func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher, waiter WaitForCompletion) error {
 	var config Config
-	timeoutError := errors.New("exceeded max wait time for TasksStopped waiter")
+
 	err := fetcher.Fetch(&config)
 	if err != nil {
 		return fmt.Errorf("plugin configuration error: %w", err)
@@ -60,29 +62,10 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 		// TODO: This is currently a magic number. If we want this to be configurable, remove the nolint directive and fix it up
 		o.MaxDelay = 10 * time.Second //nolint:mnd
 	})
-	result, err := awsinternal.WaitForCompletion(ctx, waiterClient, taskArn, config.TimeOut)
+	result, err := waiter(ctx, waiterClient, taskArn, config.TimeOut)
+	err = trp.HandleResults(ctx, result, err, buildKiteAgent, config)
 	if err != nil {
-		if errors.Is(err, timeoutError) {
-			err := buildKiteAgent.Annotate(ctx, fmt.Sprintf("Task did not complete successfully within timeout (%d seconds)", config.TimeOut), "error", "ecs-task-runner")
-			if err != nil {
-				return fmt.Errorf("failed to annotate buildkite with task timeout failure: %w", err)
-			}
-		}
-		bkerr := buildKiteAgent.Annotate(ctx, fmt.Sprintf("failed to wait for task completion: %v\n", err), "error", "ecs-task-runner")
-		if bkerr != nil {
-			return fmt.Errorf("failed to annotate buildkite with task wait failure: %w, annotation error: %w", err, bkerr)
-		}
-	} else if len(result.Failures) > 0 {
-		// There is still a scenario where the task could return failures but this isn't handled by the waiter
-		// This is due to the waiter only returning errors in scenarios where there are issues querying the task
-		// or scheduling the task. For a list of the Failures that can be returned in this case, see:
-		// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/api_failures_messages.html
-		// specifically, under the `DescribeTasks` API.
-		err := buildKiteAgent.Annotate(ctx, fmt.Sprintf("Task did not complete successfully: %v", result.Failures[0]), "error", "ecs-task-runner")
-		if err != nil {
-			return fmt.Errorf("failed to annotate buildkite with task failure: %w", err)
-		}
-		return fmt.Errorf("task did not complete successfully: %v", result.Failures[0])
+		return fmt.Errorf("failed to handle task results: %w", err)
 	}
 
 	// In a successful scenario for task completion, we would have a `tasks` slice with a single element
@@ -122,5 +105,35 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 	}
 
 	buildkite.Log("done. \n")
+	return nil
+}
+
+func (trp TaskRunnerPlugin) HandleResults(ctx context.Context, output *ecs.DescribeTasksOutput, err error, bkAgent buildkite.AgentAPI, config Config) error {
+	if err != nil {
+		// This comparison is hacky, but is the only way that I could get the wrapped errors surfaced
+		// from the AWS library to be properly handled. It would be better if this was done using errors.As
+		if strings.Contains(err.Error(), "exceeded max wait time for TasksStopped waiter") {
+			err := bkAgent.Annotate(ctx, fmt.Sprintf("Task did not complete successfully within timeout (%d seconds)", config.TimeOut), "error", "ecs-task-runner")
+			if err != nil {
+				return fmt.Errorf("failed to annotate buildkite with task timeout failure: %w", err)
+			}
+			return errors.New("task did not complete within the time limit")
+		}
+		bkerr := bkAgent.Annotate(ctx, fmt.Sprintf("failed to wait for task completion: %v\n", err), "error", "ecs-task-runner")
+		if bkerr != nil {
+			return fmt.Errorf("failed to annotate buildkite with task wait failure: %w, annotation error: %w", err, bkerr)
+		}
+	} else if len(output.Failures) > 0 {
+		// There is still a scenario where the task could return failures but this isn't handled by the waiter
+		// This is due to the waiter only returning errors in scenarios where there are issues querying the task
+		// or scheduling the task. For a list of the Failures that can be returned in this case, see:
+		// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/api_failures_messages.html
+		// specifically, under the `DescribeTasks` API.
+		err := bkAgent.Annotate(ctx, fmt.Sprintf("Task did not complete successfully: %v", output.Failures[0]), "error", "ecs-task-runner")
+		if err != nil {
+			return fmt.Errorf("failed to annotate buildkite with task failure: %w", err)
+		}
+		return fmt.Errorf("task did not complete successfully: %v", output.Failures[0])
+	}
 	return nil
 }

--- a/src/plugin/task-runner.go
+++ b/src/plugin/task-runner.go
@@ -57,7 +57,7 @@ func (trp TaskRunnerPlugin) Run(ctx context.Context, fetcher ConfigFetcher) erro
 		// TODO: This is currently a magic number. If we want this to be configurable, remove the nolint directive and fix it up
 		o.MaxDelay = 10 * time.Second //nolint:mnd
 	})
-	result, err := awsinternal.WaitForCompletion(ctx, waiterClient, taskArn)
+	result, err := awsinternal.WaitForCompletion(ctx, waiterClient, taskArn, config.TimeOut)
 	if err != nil {
 		return fmt.Errorf("failed to wait for task completion: %w\nFailure information: %v", err, result.Failures[0])
 	}

--- a/src/plugin/task-runner_test.go
+++ b/src/plugin/task-runner_test.go
@@ -1,0 +1,117 @@
+package plugin_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	awsinternal "github.com/cultureamp/ecs-task-runner-buildkite-plugin/aws"
+	"github.com/cultureamp/ecs-task-runner-buildkite-plugin/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+type MockBuildKiteAgent struct{}
+
+func (m MockBuildKiteAgent) Annotate(ctx context.Context, message string, style string, annotationContext string) error {
+	return nil
+}
+
+func TestRunPluginResponse(t *testing.T) {
+	buildKiteAgent := MockBuildKiteAgent{}
+	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME", "test-parameter")
+	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_SCRIPT", "hello-world")
+	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT", "15")
+	mockFetcher := plugin.EnvironmentConfigFetcher{}
+	var config plugin.Config
+	err := mockFetcher.Fetch(&config)
+	require.NoError(t, err)
+
+	mockContainers := map[string]types.Container{
+		"success": {
+			ExitCode: aws.Int32(0),
+			Image:    aws.String("nginx"),
+			Name:     aws.String("gateway"),
+			Reason:   aws.String("Gracefully Terminated"),
+		},
+		"failed": {
+			ExitCode: aws.Int32(1),
+			Image:    aws.String("nginx"),
+			Name:     aws.String("gateway"),
+			Reason:   aws.String("Panicked"),
+		},
+		"running": {
+			Image:  aws.String("nginx"),
+			Name:   aws.String("gateway"),
+			Reason: aws.String("Panicked"),
+		},
+	}
+
+	mockResponses := map[string]plugin.WaitForCompletion{
+		"success": func(ctx context.Context, waiter awsinternal.EcsWaiterAPI, taskArn string, timeOut int) (*ecs.DescribeTasksOutput, error) {
+			return &ecs.DescribeTasksOutput{
+				Tasks: []types.Task{{
+					Containers: []types.Container{
+						mockContainers["success"],
+					},
+					LastStatus: aws.String("STOPPED"),
+				},
+				},
+			}, nil
+		},
+		"failed": func(ctx context.Context, waiter awsinternal.EcsWaiterAPI, taskArn string, timeOut int) (*ecs.DescribeTasksOutput, error) {
+			return &ecs.DescribeTasksOutput{
+				Tasks: []types.Task{{
+					Containers: []types.Container{
+						mockContainers["failed"],
+					},
+					LastStatus: aws.String("STOPPED"),
+				},
+				},
+				Failures: []types.Failure{
+					{
+						Arn:    aws.String("test-task-arn"),
+						Reason: aws.String("Panicked"),
+						Detail: aws.String("Container gateway panicked with non-zero exit code 1"),
+					},
+				},
+			}, nil
+		},
+		"running": func(ctx context.Context, waiter awsinternal.EcsWaiterAPI, taskArn string, timeOut int) (*ecs.DescribeTasksOutput, error) {
+			return &ecs.DescribeTasksOutput{
+				Tasks: []types.Task{{
+					Containers: []types.Container{
+						mockContainers["running"],
+					},
+					LastStatus: aws.String("RUNNING"),
+				},
+				},
+			}, errors.New("exceeded max wait time for TasksStopped waiter")
+		},
+	}
+
+	expectedString := map[string]string{
+		"success": "",
+		"failed":  "task did not complete successfully",
+		"running": "task did not complete within the time limit",
+	}
+	// expectedError := map[string]error{
+	// 	"success": nil,
+	// 	"failed":  errors.New(expectedString["failed"]),
+	// 	"running": errors.New(expectedString["running"]),
+	// }
+
+	for name, mockResponse := range mockResponses {
+		t.Run(name, func(t *testing.T) {
+			result, err := mockResponse(context.TODO(), nil, "test-task-arn", 15)
+			plugin := plugin.TaskRunnerPlugin{}
+			err = plugin.HandleResults(context.TODO(), result, err, buildKiteAgent, config)
+			if err != nil {
+				require.ErrorContains(t, err, expectedString[name])
+				t.Logf("expected: %v, actual: %v", expectedString[name], err)
+			}
+		})
+	}
+}

--- a/src/plugin/task-runner_test.go
+++ b/src/plugin/task-runner_test.go
@@ -97,11 +97,6 @@ func TestRunPluginResponse(t *testing.T) {
 		"failed":  "task did not complete successfully",
 		"running": "task did not complete within the time limit",
 	}
-	// expectedError := map[string]error{
-	// 	"success": nil,
-	// 	"failed":  errors.New(expectedString["failed"]),
-	// 	"running": errors.New(expectedString["running"]),
-	// }
 
 	for name, mockResponse := range mockResponses {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
# Purpose
This PR adds an optional member to the Config struct used for passing arguments to the plugin.

This member configures how long the waiter will wait before returning a timeout.

# Context
This is part of [CSRE-4986](https://cultureamp.atlassian.net/browse/CSRE-4986) and is part of enhancing this for long running tasks.

Additionally, there are some changes to the task runner function, abstracting inputs and breaking out part to an individual function, with interfaces defined to pass mocks+actual dependencies into them for runtime.

[CSRE-4986]: https://cultureamp.atlassian.net/browse/CSRE-4986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ